### PR TITLE
fix: only call onSuccessCallback on 200 status code

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -272,9 +272,15 @@ class EventFlux extends EventFluxBase {
               );
             },
           );
-      onSuccessCallback(EventFluxResponse(
-          status: EventFluxStatus.connected,
-          stream: _streamController!.stream));
+
+      if (data.statusCode == 200) {
+        onSuccessCallback(
+          EventFluxResponse(
+            status: EventFluxStatus.connected,
+            stream: _streamController!.stream,
+          ),
+        );
+      }
     }).catchError((e) async {
       if (onError != null) {
         onError(EventFluxException(message: e.toString()));


### PR DESCRIPTION
## Why?

If the endpoint returns 404, currently still onSuccessCallback is called. This is unexpected behaviour for the developer.