### PR TITLE
fix: reconnectConfig should not be deleted

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -387,7 +387,6 @@ class EventFlux extends EventFluxBase {
   Future<EventFluxStatus> _stop() async {
     eventFluxLog('Disconnecting', LogEvent.info, _tag);
     try {
-      _reconnectConfig = null;
       _streamSubscription?.cancel();
       _streamController?.close();
       _client?.close();


### PR DESCRIPTION
The ReconnectConfig must not be deleted. This ensures that the connection is re-established even after a connection is lost, for example by switching flight mode on and off again. This pull request fixes the error in Issue #18