### PR TITLE
ci: Add CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,20 @@
+name: Continuous Integration
+
+concurrency:
+  group: $-$
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  analyze-and-test:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+    with:
+      flutter_channel: stable
+      min_coverage: 0


### PR DESCRIPTION
This PR adds a Continuous Integration workflow to ensure code quality. 

It uses the Very Good Workflows `flutter_package` workflow which analyzes and checks formatting of dart code and runs tests.

Consider setting up branch rules to enforce this check to succeed. This way we can ensure EventFlux code quality and stability.

I set the `min_coverage` to 0 for now. This should be increased as tests are added.