### PR TITLE
Fix issue38  handle u+2028 character in data line parsing

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -334,38 +334,52 @@ class EventFlux extends EventFluxBase {
                     EventFluxData(data: '', id: '', event: '');
                 return;
               }
+              try {
+                /// Removing the line separator from the data line. It breaks the parse.
+                final sanitizedDataLine = dataLine.replaceAll('\u2028', '');
 
-              /// Removing the line separator from the data line.
-              final sanitizedDataLine = dataLine.replaceAll('\u2028', '');
+                /// Parsing each line through the regex.
+                Match match = lineRegex.firstMatch(sanitizedDataLine)!;
+                var field = match.group(1);
+                if (field!.isEmpty) {
+                  return;
+                }
+                var value = '';
+                if (field == 'data') {
+                  /// If the field is data, we get the data through the substring
+                  value = dataLine.substring(5);
+                } else {
+                  value = match.group(2) ?? '';
+                }
+                switch (field) {
+                  case 'event':
+                    currentEventFluxData.event = value;
+                    break;
+                  case 'data':
+                    currentEventFluxData.data = '${currentEventFluxData.data}$value\n';
+                    break;
+                  case 'id':
+                    currentEventFluxData.id = value;
+                    break;
+                  case 'retry':
+                    break;
+                }
+              } catch (e) {
+                eventFluxLog(
+                  'Error parsing data line: $e',
+                  LogEvent.error,
+                  _tag,
+                );
 
-              /// Parsing each line through the regex.
-              Match match = lineRegex.firstMatch(sanitizedDataLine)!;
-              var field = match.group(1);
-              if (field!.isEmpty) {
-                return;
+                /// If the `onError` callback is provided, pass the error.
+                if (onError != null) {
+                  onError(
+                    EventFluxException(
+                      message: 'Error parsing data line: $e',
+                    ),
+                  );
+                }
               }
-              var value = '';
-              if (field == 'data') {
-                /// If the field is data, we get the data through the substring
-                value = dataLine.substring(5);
-              } else {
-                value = match.group(2) ?? '';
-              }
-              switch (field) {
-                case 'event':
-                  currentEventFluxData.event = value;
-                  break;
-                case 'data':
-                  currentEventFluxData.data =
-                      '${currentEventFluxData.data}$value\n';
-                  break;
-                case 'id':
-                  currentEventFluxData.id = value;
-                  break;
-                case 'retry':
-                  break;
-              }
-            },
             cancelOnError: true,
             onDone: () async {
               eventFluxLog('Stream Closed', LogEvent.info, _tag);

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -335,8 +335,11 @@ class EventFlux extends EventFluxBase {
                 return;
               }
 
+              /// Removing the line separator from the data line.
+              final sanitizedDataLine = dataLine.replaceAll('\u2028', '');
+
               /// Parsing each line through the regex.
-              Match match = lineRegex.firstMatch(dataLine)!;
+              Match match = lineRegex.firstMatch(sanitizedDataLine)!;
               var field = match.group(1);
               if (field!.isEmpty) {
                 return;

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -356,7 +356,8 @@ class EventFlux extends EventFluxBase {
                     currentEventFluxData.event = value;
                     break;
                   case 'data':
-                    currentEventFluxData.data = '${currentEventFluxData.data}$value\n';
+                    currentEventFluxData.data =
+                        '${currentEventFluxData.data}$value\n';
                     break;
                   case 'id':
                     currentEventFluxData.id = value;
@@ -380,6 +381,7 @@ class EventFlux extends EventFluxBase {
                   );
                 }
               }
+            },
             cancelOnError: true,
             onDone: () async {
               eventFluxLog('Stream Closed', LogEvent.info, _tag);


### PR DESCRIPTION
### Problem
The `lineRegex.firstMatch(dataLine)!` statement fails when the input contains the U+2028 character (Line Separator). This issue occurs because:
1. The input is not sanitized.
2. The exception is not caught, so the `onError` callback is never invoked.

### Solution
- Sanitized the input to remove the U+2028 character before parsing.
- Wrapped the parsing block in a `try-catch` to ensure errors are properly handled.